### PR TITLE
Fix missing HTTPException import for auth

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -28,7 +28,7 @@ import uuid
 from typing import Any, Dict, List, Optional
 import uvicorn
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Query, Response,  Body, Depends
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Query, Response, Body, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer


### PR DESCRIPTION
## Summary
- import HTTPException so auth endpoints raise proper errors instead of NameError

## Testing
- `../server/.venv/bin/python - <<'PY'\nfrom server import auth_login\ntry:\n    auth_login({'username':'wrong','password':'pass'})\nexcept Exception as e:\n    print('error', type(e).__name__, str(e))\nPY`
- `../server/.venv/bin/python -m py_compile server.py`
- `../server/.venv/bin/pytest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a080b734d88331beaef8cd1d113819